### PR TITLE
chore(renovate): update the docker image schedule and the policy for peerDeps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
-  "extends": [
-    "@teppeis"
-  ]
+  "extends": ["@teppeis", ":widenPeerDependencies"],
+  "circleci": {
+    "schedule": ["before 9am on Monday"]
+  }
 }


### PR DESCRIPTION
I've updated the config for Renovate like the following

* Update Circle CI images at before 9 am on Monday
* Always Update peerDeps wider