### PR TITLE
chore: remove renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,0 @@
-{
-  "extends": ["@cybozu"]
-}


### PR DESCRIPTION
We are going to migrate this repository into `kintone/js-sdk`, so we no longer need Renovate in here.
ref. https://github.com/kintone/js-sdk/pull/362